### PR TITLE
added Data.String.Interpolate.normalizeLines

### DIFF
--- a/test/Data/String/InterpolateSpec.hs
+++ b/test/Data/String/InterpolateSpec.hs
@@ -3,6 +3,7 @@ module Data.String.InterpolateSpec (main, spec) where
 
 import           Test.Hspec
 import           Test.QuickCheck
+import           Data.Char
 
 import           Data.String.Interpolate
 
@@ -32,3 +33,43 @@ spec = do
 
     it "does not prevent interpolation on literal backslash" $ do
       [i|foo \\#{23 :: Int} bar|] `shouldBe` "foo \\23 bar"
+
+  describe "normalizeLines" $ do
+    it "is total" $ do
+      property $ \ string -> length (normalizeLines string) >= 0
+
+    it "removes indentation consistently" $ do
+      normalizeLines [i|
+        foo
+          bar
+            foo
+
+        baz
+       |] `shouldBe`
+        "foo\n  bar\n    foo\n\nbaz\n"
+
+    let headMay (a : _) = Just a
+        headMay [] = Nothing
+    it "removes the first line if it only consists of whitespace" $ do
+      property $ \ text ->
+        (maybe False (any (not . isSpace)) (headMay (lines text))) ==>
+        (\ n ->
+          normalizeLines (replicate n ' ' ++ "\n" ++ text) ===
+            normalizeLines text)
+
+    it "disregards lines containing only whitespace when calculating indentation" $ do
+      normalizeLines "    foo\n  \n      \n    bar" `shouldBe`
+        "foo\n\n  \nbar"
+
+    it "allows to create strings with no trailing newline" $ do
+      normalizeLines [i|
+        foo|] `shouldBe`
+          "foo"
+
+    it "does not end with a newline when the input ends with something other than a whitespace or newline" $ do
+      property $ \ string ->
+        not (null string) ==>
+        not (last string `elem` [' ', '\n']) ==>
+        let result = normalizeLines string
+        in not (null result) ==>
+           last result /= '\n'


### PR DESCRIPTION
Inspired by so-called _indented strings_ from nix (http://nixos.org/nix/manual/#ssec-values).

This is meant as a first draft. For example I don't know yet what to do about `\t`. Also I'm not sure if this should be in this package or somewhere else.

cc: @sol @darkproger @shlevy
