### PR TITLE
interpolate.cabal: include hspec-discover as build tool

### DIFF
--- a/interpolate.cabal
+++ b/interpolate.cabal
@@ -61,6 +61,7 @@ test-suite spec
       Data.String.Interpolate.UtilSpec
       Data.String.InterpolateSpec
       Paths_interpolate
+  build-tool-depends: hspec-discover:hspec-discover
   build-depends:
       QuickCheck
     , base ==4.*


### PR DESCRIPTION
It is technically required to run the tests, so mention it explicitly.